### PR TITLE
Fix for generic BL Touch

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -810,7 +810,7 @@
    * This feature was designed for Deltabots with very fast Z moves; however, higher speed Cartesians
    * might be able to use it. If the machine can't raise Z fast enough the BLTouch may go into ALARM.
    */
-  #define BLTOUCH_HS_MODE
+  // #define BLTOUCH_HS_MODE
 
   // Safety: Enable voltage mode settings in the LCD menu.
   //#define BLTOUCH_LCD_VOLTAGE_MENU

--- a/Marlin/src/inc/Version.h
+++ b/Marlin/src/inc/Version.h
@@ -26,7 +26,7 @@
  */
 #ifndef SHORT_BUILD_VERSION
   #if ENABLED(HIGH_SPEED_1)
-    #define SHORT_BUILD_VERSION "V1.0.9.7_5"
+    #define SHORT_BUILD_VERSION "V1.0.9.7_5_noHS"
   #else
     #define SHORT_BUILD_VERSION "Ender-3V3 SE_Ten_P1T14T" // GD32F303RET6 + Multilanguage 1.Chinese 2.English 3.German 4.Russian 5.French 6.Turkish 7.Spanish 8.Italian 9.Portuguese
   #endif  


### PR DESCRIPTION
There  is an option in Config_adv that sets the touch probe to "high-speed" mode.

High-speed mode was causing my generic BL Touch to error out. Retracting the pin wasn't fast enough, and it would throw an error that it failed to retract after the first probe.

Removing the "high speed" command seems to make it work, and causes no visible (to humans) slowdown.  I suspect it's on the order of milliseconds.  If other people have broken CR Touches, like I did, and want to replace them with a cheaper generic alternative, this will make it painless for them to do so.