### PR TITLE
Increased cold extrusion temp

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -115,7 +115,7 @@
  *
  * :[2400, 9600, 19200, 38400, 57600, 115200, 250000, 500000, 1000000]
  */
-#define BAUDRATE 115200
+#define BAUDRATE 128000 // KAK
 //#define BAUD_RATE_GCODE     // Enable G-code M575 to set the baud rate
 
 /**
@@ -680,7 +680,7 @@
  * *** IT IS HIGHLY RECOMMENDED TO LEAVE THIS OPTION ENABLED! ***
  */
 #define PREVENT_COLD_EXTRUSION
-#define EXTRUDE_MINTEMP 180
+#define EXTRUDE_MINTEMP 240 // KAK
 
 /**
  * Prevent a single extrusion longer than EXTRUDE_MAXLENGTH.
@@ -1584,7 +1584,7 @@
 #if EITHER(AUTO_BED_LEVELING_LINEAR, AUTO_BED_LEVELING_BILINEAR)
 
   // Set the number of grid points per dimension.
-  #define GRID_MAX_POINTS_X 5
+  #define GRID_MAX_POINTS_X 7 // KAK
   #define GRID_MAX_POINTS_Y GRID_MAX_POINTS_X
 
   // Probe along the Y axis, advancing X after each column

--- a/Marlin/src/inc/Version.h
+++ b/Marlin/src/inc/Version.h
@@ -26,7 +26,7 @@
  */
 #ifndef SHORT_BUILD_VERSION
   #if ENABLED(HIGH_SPEED_1)
-    #define SHORT_BUILD_VERSION "V1.0.9.7_7"
+    #define SHORT_BUILD_VERSION "V1.0.9.7_7v2" // KAK
   #else
     #define SHORT_BUILD_VERSION "Ender-3V3 SE_Ten_P1T14T" // GD32F303RET6 + Multilanguage 1.Chinese 2.English 3.German 4.Russian 5.French 6.Turkish 7.Spanish 8.Italian 9.Portuguese
   #endif  
@@ -46,7 +46,7 @@
  * version was tagged.
  */
 #ifndef STRING_DISTRIBUTION_DATE
-  #define STRING_DISTRIBUTION_DATE "2025-01-29"
+  #define STRING_DISTRIBUTION_DATE "2025-01-30" // KAK
 #endif
 
 /**

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+## Changes to [@navaismo](https://github.com/navaismo/Ender-3V3-SE) fork of [v1.0.9.7_7](https://github.com/navaismo/Ender-3V3-SE/releases/tag/v1.0.9.7_7):
+- Increased the baudrate from 115200 to 128000
+- Increased the prevent cold extrusion extrusion_temp from 180c to 240c
+- Changed the bed mesh levelling from 5x5 to 7x7
+
 ## Changes to Creality's Firmware
 - Included the Autolevel-Grid to a 7x7-Mesh based on the fork of [@aschmitt1909](https://github.com/aschmitt1909/Ender-3V3-SE)
 - Included the Linear Advance functions based     on the fork of [@queeup-Forks](https://github.com/queeup-Forks/Ender-3V3-SE)


### PR DESCRIPTION
I was changing filaments during cold state (cold nozzle/no heating/no printing), triggered the filament run out sensor and it went into filament loading sequence (park > retract > wait for user > extrude > go back to position) but the nozzle only heated up to 180°C and it forced my ABS+ filament down the nozzle (it could but was not good practise maybe?).

Found line 683 PREVENT_COLD_EXTRUSION EXTRUDE_MINTEMP was at 180°C. I changed it to 240°C to suit all types of filament like the printer's default 'Extrude' function (heating nozzle to 240°C). 