### PR TITLE
Parse model metadata from GCode

### DIFF
--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -5250,7 +5250,7 @@ void DC_Show_defaut_imageOcto()
 #endif
 }
 
-static void Isplay_Estimated_Time(int time) // Display remaining time.
+static void Display_Estimated_Time(int time) // Display remaining time.
 {
   int h, m, s;
   char cmd[30] = {0};
@@ -5289,7 +5289,7 @@ static void Image_Preview_Information_Show(uint8_t ret)
       DWIN_ICON_Show(ICON, ICON_LEVEL_CALIBRATION_OFF, ICON_ON_OFF_X, ICON_ON_OFF_Y);
 #endif
   }
-  if (ret == PIC_MISS_ERR)
+  if (ret == METADATA_PARSE_ERROR)
   {
     // No image preview data
     DWIN_Draw_String(false, true, font8x16, Popup_Text_Color, Color_Bg_Black, WORD_TIME_X + DATA_OFFSET_X + 52, WORD_TIME_Y + DATA_OFFSET_Y, F("0"));
@@ -5299,28 +5299,9 @@ static void Image_Preview_Information_Show(uint8_t ret)
   }
   else
   {
-    int predict_time;
-    float height1, height2, height3, volume, Filament;
-    char char_buf[20];
-    char char_buf1[20];
-    char str_1[20] = {0};
-    predict_time = atoi((char *)model_information.pre_time);
-    height1 = atof((char *)model_information.MAXZ);
-    height2 = atof((char *)model_information.MINZ);
-    // height3 = height1 -height2;
-    height3 = atof((char *)model_information.height);
-
-    // Sprintf(char buf,"%.1f",height3);
-    sprintf_P(char_buf, PSTR("%smm"), dtostrf(height3, 1, 1, str_1));
-    Filament = atof((char *)model_information.filament);
-
-    volume = 2.4040625 * Filament;
-    // sprintf(char_buf1,"%.1f",volume);
-    // sprintf_P(char_buf1, PSTR("%smm^3"), dtostrf(volume, 1, 1, str_1));
-    Isplay_Estimated_Time(predict_time); // Show remaining time
+    Display_Estimated_Time(atoi((char *)model_information.pre_time)); // Show remaining time
     DWIN_Draw_String(false, true, font8x16, Popup_Text_Color, Color_Bg_Black, WORD_LENTH_X + DATA_OFFSET_X, WORD_LENTH_Y + DATA_OFFSET_Y, &model_information.filament[0]);
-    DWIN_Draw_String(false, true, font8x16, Popup_Text_Color, Color_Bg_Black, WORD_HIGH_X + DATA_OFFSET_X, WORD_HIGH_Y + DATA_OFFSET_Y, &model_information.height[0]); // high
-    // DWIN_Draw_String(false,true,font8x16, Popup_Text_Color, Color_Bg_Black, 175, 183, char_buf1); //Volume
+    DWIN_Draw_String(false, true, font8x16, Popup_Text_Color, Color_Bg_Black, WORD_HIGH_X + DATA_OFFSET_X, WORD_HIGH_Y + DATA_OFFSET_Y, &model_information.height[0]);
   }
 
 #endif
@@ -5480,9 +5461,10 @@ void HMI_SelectFile()
       // Cancel the suffix. For example: filename.gcode and remove .gocde.
       make_name_without_ext(str, name);
       Draw_Title(str);
-      uint8_t ret = PIC_MISS_ERR;
+      uint8_t ret = METADATA_PARSE_ERROR;
       // Ender-3v3 SE temporarily does not support the image preview function to prevent freezing and displays the default preview image.
-      ret = gcodePicDataSendToDwin(card.filename, VP_OVERLAY_PIC_PREVIEW_1, PRIWIEW_PIC_FORMAT_NEED, PRIWIEW_PIC_RESOLITION_NEED);
+      // ret = gcodePicDataSendToDwin(card.filename, VP_OVERLAY_PIC_PREVIEW_1, PRIWIEW_PIC_FORMAT_NEED, PRIWIEW_PIC_RESOLITION_NEED);
+      ret = read_gcode_model_information(card.filename);
       // if(ret == PIC_MISS_ERR)
       DC_Show_defaut_image();              // Since this project does not have image preview data, the default small robot image is displayed.
       Image_Preview_Information_Show(ret); // Picture preview details display
@@ -8861,6 +8843,20 @@ void Remove_card_window_check(void)
   }
 }
 
+duration_t estimate_remaining_time(const duration_t elapsed)
+{
+  if (model_information.pre_time != NULL) {
+    return duration_t(atoi((char *)model_information.pre_time) - elapsed.value);
+  }
+  // remaining time is remaining file size (total file size minus current file position) times "speed" (file position per elapsed time).
+  // _fileFraction = (_card_percent * 0.01f);
+  // _elapsedTime = (elapsed.value - dwin_heat_time);
+  // _speed = (_fileFraction * (float)card.getFileSize()) / _elapsedTime;
+  // _remainSize = (float)card.getFileSize() * (1 - _fileFraction);
+  // _remain_time = _speed * _remainSize;
+  return duration_t((((_card_percent * 0.01f) * (float)card.getFileSize()) / ((elapsed.value + 1) - dwin_heat_time)) * ((float)card.getFileSize() * (100 - _card_percent)));
+}
+
 void EachMomentUpdate()
 {
   static float card_Index = 0;
@@ -9180,29 +9176,10 @@ void EachMomentUpdate()
 
     // Estimate remaining time every 20 seconds
     static millis_t next_remain_time_update = 0;
-    if (_card_percent >= 1 && ELAPSED(ms, next_remain_time_update) && !HMI_flag.heat_flag) // Rock 20210922
-    {
-      // _remain_time = (elapsed.value -dwin_heat_time) /(_card_percent *0.01f) -(elapsed.value -dwin_heat_time);
-      card_Index = card.getIndex();
-      // card_Index = 1;
-      // rock_20211115 Solve the problem of occasionally abnormal display of remaining time >100H
-      if (card_Index > 0)
-      {
-        _remain_time = ((elapsed.value - dwin_heat_time) * ((float)card.getFileSize() / card_Index)) - (elapsed.value - dwin_heat_time);
-      }
-      else
-      {
-        _remain_time = 0;
-      }
-      next_remain_time_update += DWIN_REMAIN_TIME_UPDATE_INTERVAL;
-      Draw_Print_ProgressRemain();
-    }
-    else if (_card_percent <= 1 && ELAPSED(ms, next_remain_time_update))
-    {
-      // rock_20210831 solves the problem that the remaining time is not cleared.
-      _remain_time = 0;
-      Draw_Print_ProgressRemain();
-    }
+    _remain_time = estimate_remaining_time(elapsed).value;
+
+    next_remain_time_update += DWIN_REMAIN_TIME_UPDATE_INTERVAL;
+    Draw_Print_ProgressRemain();
   }
   else if (dwin_abort_flag && !HMI_flag.home_flag)
   {

--- a/Marlin/src/lcd/dwin/e3v2/dwin.h
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.h
@@ -31,6 +31,8 @@
 
 #include "../../../inc/MarlinConfigPre.h"
 
+#include "../../../src/libs/duration_t.h"
+
 #if ANY(HAS_HOTEND, HAS_HEATED_BED, HAS_FAN) && PREHEAT_COUNT
   #define HAS_PREHEAT 1
   #if PREHEAT_COUNT < 2
@@ -943,6 +945,7 @@ void Draw_Status_Area(bool with_update);
 void Draw_Mid_Status_Area(bool with_update);
 void update_variable();
 void update_middle_variable();
+duration_t estimate_remaining_time(const duration_t elapsed);
 void Draw_laguage_Cursor(uint8_t line);
 void In_out_feedtock(uint16_t _distance,uint16_t _feedRate,bool dir);
 void In_out_feedtock_level(uint16_t _distance,uint16_t _feedRate,bool dir);

--- a/Marlin/src/lcd/dwin/e3v2/lcd_rts.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/lcd_rts.cpp
@@ -55,9 +55,9 @@ bool gcodePicGetDataFormBase64(char * buf, unsigned long picLen, bool resetFlag)
   // 清除上次记录 -- Clear last record
   if (resetFlag)
   {
-    for (int i = 0; i < sizeof(base64_out); i++)
+    for (int i = 0; i < (signed)sizeof(base64_out); i++)
     {
-      base64_out[i] = '0x00';
+      base64_out[i] = 0x00;
     }
     deCodeBase64Cnt = 0;
     return true;
@@ -206,162 +206,112 @@ void gcodePicDispalyOnOff(unsigned int jpgAddr, bool onoff)
 model_information_t model_information;
 static const char * gcode_information_name[] =
 {
-  "TIME","Filament used","Layer height","MINX",
-  "MINY","MINZ","MAXX","MAXY","MAXZ"
+  "TIME","Filament used","Layer height"
 };
-//PIC_OK;
-#define READ_PIC_TIME            500  //读取图片预览数据超时时间 -- Timeout for reading image preview data
-uint8_t read_gcode_model_information(void)
-{ 
-  millis_t ms = millis();
-  millis_t next_read_pic_ms = millis()+READ_PIC_TIME;
-  int32_t  temp_value=0;
-  char buf[50];
-  char buf_true[50] = {0};
-  unsigned char i,j,k;
+uint8_t read_gcode_model_information(const char* fileName)
+{
+  char string_buf[_GCODE_METADATA_STRING_LENGTH_MAX + 1];
   char *char_pos;
-  char ret;
+  char byte;
   unsigned char buf_state = 0;
-  uint8_t loop_max=0;
-  // SERIAL_ECHOLNPAIR("  millis()=: ", millis()); // rock_20210909
-  // SERIAL_ECHOLNPAIR(" next_read_pic_ms=: ", next_read_pic_ms); // rock_20210909
-  while(ret != ';')
+  uint8_t line_idx=0;
+  
+  card.openFileRead(fileName);
+
+  while((line_idx++) < _MAX_LINES_TO_PARSE)
   {
-    temp_value= (millis()-next_read_pic_ms);
-    ret = card.get();
-    // SERIAL_ECHOLNPAIR(" temp_value=: ",  temp_value); // rock_20210909 
-    if(temp_value>0)
+    for (int i = 0; i < _GCODE_METADATA_STRING_LENGTH_MAX; i++)
     {
-      return PIC_MISS_ERR;
+      byte = card.get();
+
+      if (i == 0 && byte != ';') break; // skip non-comment strings
+
+      if (byte == '\r' || byte == '\n')
+      {
+        string_buf[i] = '\0';
+        break;
+      }
+
+      // If you can't find ';' beyond max line length, it means the file is wrong.
+      if (i + 1 == _GCODE_METADATA_STRING_LENGTH_MAX)
+      {
+        memset(model_information.pre_time, 0, sizeof(model_information.pre_time));
+        memset(model_information.filament, 0, sizeof(model_information.filament));
+        memset(model_information.height, 0, sizeof(model_information.height));
+        
+        return METADATA_PARSE_ERROR;
+      }
+
+      string_buf[i] = byte;
+    }
+    byte = 0;
+
+    #if ENABLED(USER_LOGIC_DEUBG)
+      SERIAL_ECHOLNPAIR("Input string: ", string_buf);
+    #endif
+
+    char* char_pos = string_buf;
+    // Skip leading semicolons and spaces
+    while (*char_pos == ';' || *char_pos == ' ') {
+        char_pos++;
+    }
+
+    // Check for each keyword
+    for(int k = 0; k < (signed)(sizeof(gcode_information_name) / sizeof(gcode_information_name[0])); k++)
+    {
+      // Check if the string starts with the keyword
+      // Corresponding data has been found
+      if (strncmp(char_pos, gcode_information_name[k], strlen(gcode_information_name[k])) == 0) {
+        // Move the pointer after the keyword
+        const char* value_buf = string_buf + strlen(gcode_information_name[k]) + 1;
+        
+        // Skip optional symbols
+        while (*value_buf == ':' || *value_buf == ' ' || *value_buf == '=') {
+            value_buf++;
+        }
+        #if ENABLED(USER_LOGIC_DEUBG)
+          SERIAL_ECHOLNPAIR("Parsed value_buf: ", value_buf);
+        #endif
+        
+        buf_state++;
+        switch(k)
+        {
+          case 0: // "TIME"
+            memset(model_information.pre_time, 0, sizeof(model_information.pre_time));
+            strcpy(model_information.pre_time, value_buf);
+            break;
+          case 1: // "Filament used"
+            memset(model_information.filament, 0, sizeof(model_information.filament));           
+            if(strlen(value_buf)>6)
+            {
+              strncpy(model_information.filament, value_buf,5);
+              if('m'==value_buf[strlen(value_buf)-1])
+              strncat(model_information.filament, &value_buf[strlen(value_buf)-1],1);
+              else if('m'==value_buf[strlen(value_buf)-2])strncat(model_information.filament, &value_buf[strlen(value_buf)-2],1);
+            }
+            else {
+              strcpy(model_information.filament, value_buf);
+            }
+            break;
+          case 2: // "Layer height"
+            memset(model_information.height, 0, sizeof(model_information.height));
+            strcpy(model_information.height, value_buf);
+            strcat(model_information.height, "mm");
+            break;
+        }
+        memset(string_buf, 0, sizeof(string_buf));
+      }
+    }
+    if(buf_state == (sizeof(gcode_information_name) / sizeof(char*)))
+    {
+      // Exit the loop
+      return METADATA_PARSE_OK;
     }
   }
   
-  while((loop_max++)<5)
-  {
-    i = 0;
-    memset(buf_true, 0, sizeof(buf_true));
-    // ret=0;
-    // 搜索到下一个;字符,就结束 -- The search ends when the next; character is found
-    next_read_pic_ms = millis()+READ_PIC_TIME;
-    while(ret != ';')
-    {
-      //temp_value= (millis()-next_read_pic_ms);
-      ret = card.get();
-      buf[i] = ret;
-      i++;
-      // 如果找了很多都没找到';',说明文件错误,直接退出 -- If you can't find ';' after searching a lot, it means the file is wrong and exit directly.
-      if(i > 50)
-      {
-        goto gcode_information_err;
-      }
-      // 结束,buf[]包含结束';' -- // End, buf[] contains end ';'
-    }
-    // SERIAL_ECHO_MSG("buf:",buf);
-    // for(k = 0;k < 9;k++)
-    for(k = 0;k < 3;k++)
-    {
-      // 查找关键字 -- // Find keywords
-      char_pos = strstr(buf, gcode_information_name[k]);
-      // 已经找到相对应的数据 -- // Corresponding data has been found
-      if(char_pos != NULL)
-      {
-        // 舍去文字,直接提取数值 -- // Remove the text and extract the value directly
-        char_pos+=strlen(gcode_information_name[k]);
-        while (1)
-        {
-          // 跳过冒号 -- skip colon
-          // char_pos++;
-          if(*char_pos++ == ':')break;
-        }
-        for(j = 0;j < 15 ;j++)
-        {
-          buf_true[j] = *char_pos;
-          char_pos++;
-          if(*char_pos == '\r')
-          {
-            break;
-          }
-        }
-        // SERIAL_ECHOLNPAIR(" strlen(buf_true)=: ", strlen(buf_true)); // rock_20210909
-        if(' '==buf_true[0])strncpy(buf_true, buf_true+1,strlen(buf_true));//去除字符串前面的空格 -- Remove spaces in front of string
-        i = 0;
-        memset(buf, 0, sizeof(buf));
-        // SERIAL_ECHOLN(buf_true);
-        switch(k)
-        {
-          case 0:
-            memset(model_information.pre_time, 0, sizeof(model_information.pre_time));
-            strcpy(model_information.pre_time, buf_true);
-            break;
-          case 1:
-            memset(model_information.filament, 0, sizeof(model_information.filament));           
-            if(strlen(buf_true)>6)
-            {
-              strncpy(model_information.filament, buf_true,5);
-              if('m'==buf_true[strlen(buf_true)-1])
-              strncat(model_information.filament, &buf_true[strlen(buf_true)-1],1);
-              else if('m'==buf_true[strlen(buf_true)-2])strncat(model_information.filament, &buf_true[strlen(buf_true)-2],1);
-            }
-            else strcpy(model_information.filament, buf_true);
-            break;
-          case 2:
-            memset(model_information.height, 0, sizeof(model_information.height));
-            strcpy(model_information.height, buf_true);
-            strcat(model_information.height, "mm");
-            buf_state = 1;
-            break;
-        }
-        // break;
-      }
-    }
-    ret = 0;  //清空ret -- Clear ret
-    if(buf_state)
-    {
-      /*
-      SERIAL_ECHOLN("model_information end");
-      SERIAL_ECHOLN(model_information.pre_time);
-      SERIAL_ECHOLN(model_information.height);
-      SERIAL_ECHOLN(model_information.MAXX);
-      SERIAL_ECHOLN(model_information.MAXY);
-      SERIAL_ECHOLN(model_information.MAXZ);
-      SERIAL_ECHOLN(model_information.MINX);
-      SERIAL_ECHOLN(model_information.MINY);
-      SERIAL_ECHOLN(model_information.MINZ);
-      SERIAL_ECHOLN(model_information.filament);
-      */
-      // Exit the loop
-      return PIC_OK;
-    }
-    // else 
-    // {
-    //    SERIAL_ECHOLNPAIR(" buf_state4444=: ", buf_state); // rock_20210909
-    //   return PIC_MISS_ERR;
-    // }
-  }
-  return PIC_MISS_ERR;
-  gcode_information_err:
-    memset(model_information.pre_time, 0, sizeof(model_information.pre_time));
-    memset(model_information.filament, 0, sizeof(model_information.filament));
-    memset(model_information.height, 0, sizeof(model_information.height));
-    memset(model_information.MINX, 0, sizeof(model_information.MINX));
-    memset(model_information.MINY, 0, sizeof(model_information.MINY));
-    memset(model_information.MINZ, 0, sizeof(model_information.MINZ));
-    memset(model_information.MAXX, 0, sizeof(model_information.MAXX));
-    memset(model_information.MAXY, 0, sizeof(model_information.MAXY));
-    memset(model_information.MAXZ, 0, sizeof(model_information.MAXZ));
-    // SERIAL_ECHOLN("model_information error");
-    // SERIAL_ECHOLNPAIR(" buf_state5554=: ", buf_state); // rock_20210909
-    return PIC_MISS_ERR;
+  return METADATA_PARSE_ERROR;
 }
 
-/**
- * @功能   从gcode里面读取jpeg图片显示：1、发送到屏显示；2、让指针跳过这段图片，再去寻找下一张图片
- * @Author Creality
- * @Time   2021-12-01
- * picLenth     : 图片长度(base64编码的长度)
- * isDisplay    : 是否显示该图片
- * jpgAddr      : 显示图片的地址
- */
 /**
  * @Function Read the jpeg picture display from gcode: 
  *      1. Send it to the screen display; 
@@ -427,7 +377,7 @@ bool gcodePicDataRead(unsigned long picLenth, char isDisplay, unsigned long jpgA
     gcodePicDispalyOnOff(jpgAddr, true);
   }
 
-  read_gcode_model_information();
+  read_gcode_model_information(card.filename);
   return true;
 }
 

--- a/Marlin/src/lcd/dwin/e3v2/lcd_rts.h
+++ b/Marlin/src/lcd/dwin/e3v2/lcd_rts.h
@@ -47,6 +47,14 @@ enum{
   PIC_MISS_ERR,        // gcode无图片
 };
 
+enum{
+  METADATA_PARSE_OK,
+  METADATA_PARSE_ERROR,
+};
+
+#define _GCODE_METADATA_STRING_LENGTH_MAX 80
+#define _MAX_LINES_TO_PARSE 50
+
 typedef struct _model_information_t
 {
   char pre_time[15]; // 预定时间
@@ -96,6 +104,6 @@ extern model_information_t model_information;
 
 extern uint8_t gcodePicDataSendToDwin(char *, unsigned int , unsigned char , unsigned char );
 extern uint8_t OctoDWINPreview();
-extern uint8_t read_gcode_model_information(void);
+extern uint8_t read_gcode_model_information(const char* fileName);
 extern char Parse_Only_Picture_Data(char* fileName,char * time, char * FilamentUsed, char * layerHeight);
 #endif


### PR DESCRIPTION
Currently firmware does not parse any metadata from the gcode file and uses crude approximation algorithm to show print time. Parsing basic model parameters not only allows showing them in file select menu, but also show proper print time estimation during the print

This should mostly fix the #35 as it now uses parsed metadata from gcode, generated by Cura/PrusaSlicer/CrealityPrint. It does not support metadata provided by OrcaSlicer, since it's given at the end of the file and is of completely different format.

![image](https://github.com/user-attachments/assets/364f50ee-57a5-4297-ad42-4e359c722feb)

![image](https://github.com/user-attachments/assets/7e200291-4f05-4e7c-8c5a-3c05c4e3911c)