### PR TITLE
fix(lcd/dwin): add missing break

### DIFF
--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -6653,8 +6653,7 @@ void HMI_Display_Menu(){
       break; 
     case 5:
       settings.save();    
-  
-
+      break;
     }
   }
   DWIN_UpdateLCD();


### PR DESCRIPTION
Add missing break statement in the last case statement

No functional change