### PR TITLE
Remember last selected Bed level grid point when editing Bed leveling values.

### DIFF
--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -7594,8 +7594,7 @@ void HMI_Leveling()
       {
         gcode.process_subcommands_now_P(PSTR("M420 S0"));
         checkkey = Level_Value_Edit;
-        select_level.reset();
-        xy_int8_t mesh_Count = {0, 0};
+        xy_int8_t mesh_Count = Converted_Grid_Point(select_level.now);
         Draw_Dots_On_Screen(&mesh_Count, 1, Select_Block_Color);
         EncoderRate.enabled = true;
         DO_BLOCKING_MOVE_TO_Z(5, 5); // Raise to a height of 5mm each time before moving
@@ -7619,6 +7618,7 @@ void HMI_Leveling()
       {
         Goto_MainMenu(); // Return to the main interface
       }
+      select_level.reset();
       // HMI_flag.Refresh_bottom_flag=false;//The flag does not refresh the bottom parameters
       // Draw_Mid_Status_Area(true); //rock_20230529 //Update all parameters once
     }


### PR DESCRIPTION
When editing Bed leveling grid values, each edit procedure starts over from the first (which is bottom left) cell. On stock 4x4 grid it's ok, but with larger grids scrolling and remembering which value was edited last is rather tedious.

This patch fixes that: printer will now remember which grid cell was edited last time and only resets selected grid between grid level edit screens.

This fix addresses #70 