### PR TITLE
Adjust brightness levels to fit actual 0-64 range

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -206,9 +206,9 @@
  */
 #define ENABLE_AUTO_OFF_DISPLAY
   #if ENABLED(ENABLE_AUTO_OFF_DISPLAY)
-  extern int16_t TURN_OFF_TIME;                // turn-off time: 5min
-  extern int16_t DIMM_SCREEN_BRIGHTNESS;             // brightness 0x00-0xff:0
-  extern int16_t MAX_SCREEN_BRIGHTNESS;              // brightness 0x00-0xff:0
+  extern uint8_t TURN_OFF_TIME;                      // turn-off time: 5min
+  extern uint8_t DIMM_SCREEN_BRIGHTNESS;             // brightness 0x00-0xff:0
+  extern uint8_t MAX_SCREEN_BRIGHTNESS;              // brightness 0x00-0xff:0
 #endif
 
 /**

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1685,9 +1685,10 @@ uint8_t CZ_AFTER_HOMING = 10;
 
 
 #if ENABLED(ENABLE_AUTO_OFF_DISPLAY)
-int16_t DIMM_SCREEN_BRIGHTNESS = 175;
-int16_t MAX_SCREEN_BRIGHTNESS = 230;
-int16_t TURN_OFF_TIME = 5;
+// Maximum value supported by screen is 0x40 (64)
+uint8_t DIMM_SCREEN_BRIGHTNESS = 44;
+uint8_t MAX_SCREEN_BRIGHTNESS = 57;
+uint8_t TURN_OFF_TIME = 5;
 
 // Smoothly dim brightness
 // void dimm_brightness() {

--- a/Marlin/src/gcode/lcd/M256.cpp
+++ b/Marlin/src/gcode/lcd/M256.cpp
@@ -1,24 +1,24 @@
-// /**
-//  * Marlin 3D Printer Firmware
-//  * Copyright (c) 2021 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
-//  *
-//  * Based on Sprinter and grbl.
-//  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
-//  *
-//  * This program is free software: you can redistribute it and/or modify
-//  * it under the terms of the GNU General Public License as published by
-//  * the Free Software Foundation, either version 3 of the License, or
-//  * (at your option) any later version.
-//  *
-//  * This program is distributed in the hope that it will be useful,
-//  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  * GNU General Public License for more details.
-//  *
-//  * You should have received a copy of the GNU General Public License
-//  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
-//  *
-//  */
+// // /**
+// //  * Marlin 3D Printer Firmware
+// //  * Copyright (c) 2021 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+// //  *
+// //  * Based on Sprinter and grbl.
+// //  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+// //  *
+// //  * This program is free software: you can redistribute it and/or modify
+// //  * it under the terms of the GNU General Public License as published by
+// //  * the Free Software Foundation, either version 3 of the License, or
+// //  * (at your option) any later version.
+// //  *
+// //  * This program is distributed in the hope that it will be useful,
+// //  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+// //  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// //  * GNU General Public License for more details.
+// //  *
+// //  * You should have received a copy of the GNU General Public License
+// //  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// //  *
+// //  */
 // #include "../../inc/MarlinConfig.h"
 
 // #if ENABLED(DWIN_CREALITY_LCD)
@@ -28,8 +28,8 @@
 // #include "../../lcd/dwin/e3v2/dwin.h"
 
 // void GcodeSuite::M256_report() {
-//     SERIAL_ECHOLNPAIR("Display Max Brightness: ", ((MAX_SCREEN_BRIGHTNESS-164)*100)/66);
-//     SERIAL_ECHOLNPAIR("Display Dimm Brightness: ", ((DIMM_SCREEN_BRIGHTNESS-164)*100)/66);
+//     SERIAL_ECHOLNPAIR("Display Max Brightness: ", (MAX_SCREEN_BRIGHTNESS*100)/64);
+//     SERIAL_ECHOLNPAIR("Display Dimm Brightness: ", (DIMM_SCREEN_BRIGHTNESS*100)/64);
 //   }
 
 // /**
@@ -42,9 +42,8 @@
 //       SERIAL_ECHOLNPGM("Invalid value for M256 B<percentage>! (0-100)");    
 //       return;
 //     }
-//     int16_t luminance = 164 + ((b * 66) / 100);
-//     MAX_SCREEN_BRIGHTNESS = luminance;
-//     DWIN_Backlight_SetLuminance(luminance);
+//     MAX_SCREEN_BRIGHTNESS = (uint8_t)(((uint16_t)b * 64) / 100);
+//     DWIN_Backlight_SetLuminance(MAX_SCREEN_BRIGHTNESS);
 //     settings.save();
     
 //   } else if (parser.seenval('D')) {
@@ -53,8 +52,7 @@
 //       SERIAL_ECHOLNPGM("Invalid value for M256 D<percentage>! (0-100)");    
 //       return;
 //     }
-//     int16_t luminance = 164 + ((d * 66) / 100);
-//     DIMM_SCREEN_BRIGHTNESS = luminance;
+//     DIMM_SCREEN_BRIGHTNESS = (uint8_t)(((uint16_t)d * 64) / 100);
 //     settings.save();
     
 //   } 

--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -6757,12 +6757,12 @@ void Draw_Display_Menu(){
   // There's no graphical asset for this label, so we just write it as string
   DWIN_Draw_Label(MBASE(2), F("Max Brightness(%)"));
   Draw_Menu_Line(2, ICON_PrintSize);
-  DWIN_Draw_IntValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, VALUERANGE_X, MBASE(2) + 3 , ((MAX_SCREEN_BRIGHTNESS-164)*100)/66);
+  DWIN_Draw_IntValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, VALUERANGE_X, MBASE(2) + 3 , (MAX_SCREEN_BRIGHTNESS*100)/64);
 
   // There's no graphical asset for this label, so we just write it as string
   DWIN_Draw_Label(MBASE(3), F("Dimm Brightness(%)"));
   Draw_Menu_Line(3, ICON_Hardware_version);
-  DWIN_Draw_IntValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, VALUERANGE_X, MBASE(3) + 3 , ((DIMM_SCREEN_BRIGHTNESS-164)*100)/66);
+  DWIN_Draw_IntValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, VALUERANGE_X, MBASE(3) + 3 , (DIMM_SCREEN_BRIGHTNESS*100)/64);
 
   // There's no graphical asset for this label, so we just write it as string
   DWIN_Draw_Label(MBASE(4), F(" Mins Before Dimm"));
@@ -6831,13 +6831,13 @@ void HMI_Display_Menu(){
     case 2: // Max Brightness
       checkkey = Max_LCD_Bright;
       //LIMIT(HMI_ValueStruct.LCD_MaxBright, 0, 100);
-      DWIN_Draw_IntValue(true, true, 0, font8x16, Color_White, Select_Color, 3, VALUERANGE_X, MBASE(2) + 3, ((MAX_SCREEN_BRIGHTNESS-164)*100)/66);
+      DWIN_Draw_IntValue(true, true, 0, font8x16, Color_White, Select_Color, 3, VALUERANGE_X, MBASE(2) + 3, (MAX_SCREEN_BRIGHTNESS*100)/64);
       EncoderRate.enabled = true;
       break;
     case 3: // Dim Brightness
       checkkey = Dimm_Bright;
       //LIMIT(HMI_ValueStruct.LCD_DimmBright, 0, 100);
-      DWIN_Draw_IntValue(true, true, 0, font8x16, Color_White, Select_Color, 3, VALUERANGE_X, MBASE(3) + 3, ((DIMM_SCREEN_BRIGHTNESS-164)*100)/66);
+      DWIN_Draw_IntValue(true, true, 0, font8x16, Color_White, Select_Color, 3, VALUERANGE_X, MBASE(3) + 3, (DIMM_SCREEN_BRIGHTNESS*100)/64);
       EncoderRate.enabled = true;
       break;
     case 4: // Dim Time
@@ -6909,9 +6909,8 @@ void HMI_LCDBright(){
     LIMIT(HMI_ValueStruct.LCD_MaxBright, 5, 100);
     checkkey = Display_Menu;
     DWIN_Draw_IntValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, VALUERANGE_X, MBASE(2)+3 , HMI_ValueStruct.LCD_MaxBright);
-    int16_t luminance = 164 + ((HMI_ValueStruct.LCD_MaxBright * 66) / 100);
-    MAX_SCREEN_BRIGHTNESS = luminance;
-    DWIN_Backlight_SetLuminance(luminance);
+    MAX_SCREEN_BRIGHTNESS = (uint8_t)(((uint16_t)HMI_ValueStruct.LCD_MaxBright * 64) / 100);
+    DWIN_Backlight_SetLuminance(MAX_SCREEN_BRIGHTNESS);
     //save to eeprom
     return;
   }
@@ -6931,8 +6930,7 @@ void HMI_LCDDimm(){
     LIMIT(HMI_ValueStruct.LCD_DimmBright, 0, 100);
     checkkey = Display_Menu;
     DWIN_Draw_IntValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, VALUERANGE_X, MBASE(3)+3 , HMI_ValueStruct.LCD_DimmBright);
-    int16_t luminance = 164 + ((HMI_ValueStruct.LCD_DimmBright * 66) / 100);
-    DIMM_SCREEN_BRIGHTNESS = luminance;
+    DIMM_SCREEN_BRIGHTNESS = (uint8_t)(((uint16_t)HMI_ValueStruct.LCD_DimmBright * 64) / 100);
     //save to eeprom
     return;
   }

--- a/Marlin/src/lcd/dwin/e3v2/dwin.h
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.h
@@ -682,8 +682,8 @@ typedef struct
     celsius_t E_Temp = 0;
     int16_t E_Flow = 0;
     int16_t Extrusion_Length = 0;
-    int16_t LCD_MaxBright  = MAX_SCREEN_BRIGHTNESS;
-    int16_t LCD_DimmBright = DIMM_SCREEN_BRIGHTNESS;
+    uint8_t LCD_MaxBright  = MAX_SCREEN_BRIGHTNESS;
+    uint8_t LCD_DimmBright = DIMM_SCREEN_BRIGHTNESS;
     uint8_t Dimm_Time = TURN_OFF_TIME;
     uint8_t Z_height = CZ_AFTER_HOMING;
   #endif

--- a/Marlin/src/lcd/dwin/e3v2/rotary_encoder.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/rotary_encoder.cpp
@@ -86,12 +86,12 @@ void Encoder_tick() {
 
 // restore brightness smoothly
 // void restore_brightness() {
-//   const uint16_t step_delay = 10; // Smaller delay for smoother animation
+//   const uint8_t step_delay = 10; // Smaller delay for smoother animation
 //   const uint8_t steps = 15;       // More steps for finer control
 
-//   int16_t current_brightness = DIMM_SCREEN_BRIGHTNESS;
-//   int16_t brightness_range = MAX_SCREEN_BRIGHTNESS - DIMM_SCREEN_BRIGHTNESS;
-//   int16_t step_size = brightness_range / steps; // Automatically adapt to range
+//   uint8_t current_brightness = DIMM_SCREEN_BRIGHTNESS;
+//   uint8_t brightness_range = MAX_SCREEN_BRIGHTNESS - DIMM_SCREEN_BRIGHTNESS;
+//   uint8_t step_size = brightness_range / steps; // Automatically adapt to range
 
 //   // Make sure step size is at least 1 to prevent infinite loop
 //   if (step_size < 1) step_size = 1;

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -36,7 +36,7 @@
  */
 
 // Change EEPROM version if the structure changes
-#define EEPROM_VERSION "V90"
+#define EEPROM_VERSION "V91"
 #define EEPROM_OFFSET 100
 
 // Check the integrity of data offsets.
@@ -1503,18 +1503,23 @@ void MarlinSettings::postprocess() {
     #endif
 
      //Save LCD Brightness settings
-     #if ENABLED(ENABLE_AUTO_OFF_DISPLAY)
-     {
-       uint8_t sleep = TURN_OFF_TIME;                
-       int16_t dimmBright = DIMM_SCREEN_BRIGHTNESS;
-       int16_t bright = MAX_SCREEN_BRIGHTNESS;
-       uint8_t zheight = CZ_AFTER_HOMING;
-       EEPROM_WRITE(sleep);              
-       EEPROM_WRITE(dimmBright);         
-       EEPROM_WRITE(bright);             
-       EEPROM_WRITE(zheight); 
-     }             
-     #endif
+    #if ENABLED(ENABLE_AUTO_OFF_DISPLAY)
+    {
+      uint8_t sleep = TURN_OFF_TIME;
+      uint8_t dimmBright = DIMM_SCREEN_BRIGHTNESS;
+      uint8_t bright = MAX_SCREEN_BRIGHTNESS;
+      EEPROM_WRITE(sleep);
+      EEPROM_WRITE(dimmBright);
+      EEPROM_WRITE(bright);
+    }
+    #endif
+
+    #if HAS_HOTEND
+    {
+      uint8_t zheight = CZ_AFTER_HOMING;
+      EEPROM_WRITE(zheight);
+    }
+    #endif
 
     #if ENABLED(ADVANCED_HELP_MESSAGES)
     {
@@ -2490,15 +2495,20 @@ void MarlinSettings::postprocess() {
     #if ENABLED(ENABLE_AUTO_OFF_DISPLAY)
     {
       uint8_t sleep;                 
-      int16_t dimmBright;
-      int16_t bright;
-      uint8_t zheight;
+      uint8_t dimmBright;
+      uint8_t bright;
       EEPROM_READ(sleep);
       TURN_OFF_TIME = (sleep > 60) ? 5 : sleep;              
       EEPROM_READ(dimmBright);
       DIMM_SCREEN_BRIGHTNESS = (dimmBright > 175) ? 175  : dimmBright;         
       EEPROM_READ(bright);             
       MAX_SCREEN_BRIGHTNESS = ( bright > 230) ? 230 : bright;
+    }
+    #endif
+
+    #if HAS_HOTEND
+    {
+      uint8_t zheight;
       EEPROM_READ(zheight);
       CZ_AFTER_HOMING = (zheight >= 10) ? zheight : 10; //Set default value
     }


### PR DESCRIPTION
The actual range of brightness for this screen is 0x00-0x40 (0-64), thus we should properly read and store that value, interpolating from 100% in UI.

Also, switching from `uint16_t` and `int16_t` to `uint8_t` for brightness variables slightly reduced RAM usage, from:
```
RAM:   [====      ]  39.5% (used 25912 bytes from 65536 bytes)
Flash: [=====     ]  50.6% (used 265516 bytes from 524288 bytes)
```
to
```
RAM:   [====      ]  39.5% (used 25896 bytes from 65536 bytes)
Flash: [=====     ]  50.6% (used 265412 bytes from 524288 bytes)
```