### PR TITLE
Show tips when cancelling print

### DIFF
--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -2917,18 +2917,29 @@ void Popup_window_PauseOrStop()
     }
     else if (select_print.now == 2)
     {
-      DWIN_ICON_Show(HMI_flag.language, LANGUAGE_StopPrint, 14, 45);
+      #if ENABLED(ADVANCED_HELP_MESSAGES)
+        if (HMI_flag.advanced_help_enabled_flag)
+        {
+          if (ui.get_progress_percent() < 1) {
+            DWIN_Draw_qrcode(10, 60, 3, "https://bit.ly/NAVAISMO-BED-ADHESION");
+            DWIN_Draw_MultilineString(false, false, font8x16, Color_White, Color_Bg_Window, 92, 60, 17, 17, "Having issues with bed adhesion? See our community Wiki for help");
+          } else {
+            DWIN_Draw_qrcode(10, 60, 3, "https://bit.ly/NAVAISMO-PRINT-FAILS");
+            DWIN_Draw_MultilineString(false, false, font8x16, Color_White, Color_Bg_Window, 92, 60, 17, 17, "Did your print fail? See our community Wiki for common issues");
+          }
+        }
+        else
+      #endif
+      {
+        DWIN_ICON_Show(HMI_flag.language, LANGUAGE_StopPrint, 14, 45);
+      }
     }
-    else if(select_print.now == 20){
-      
+    else if(select_print.now == 20)
+    {
       DWIN_Draw_String(false, false, DWIN_FONT_HEAD, Color_White, Color_Bg_Window, 14, 45, F("Reset Settings?"));
-     
     }
     DWIN_ICON_Not_Filter_Show(HMI_flag.language, LANGUAGE_Confirm, 26, 194);
     DWIN_ICON_Not_Filter_Show(HMI_flag.language, LANGUAGE_Cancel, 132, 194);
-  }
-  else
-  {
   }
   Draw_Select_Highlight(true);
 #endif


### PR DESCRIPTION
Add a helpful QR code and a hint to the print cancel screen

Solves #57

![image](https://github.com/user-attachments/assets/52a2f495-421d-40c1-a6b0-5ece51d08384)

![image](https://github.com/user-attachments/assets/48cbe578-c272-4f76-9c15-c307efae3840)

This feature may introduce printing hiccups during the QR code rendering, thus might be adding visual defects in case user clicks Stop but doesn't actually confirms it and decides to print anyways. Realistically, this most probably shouldn't be an issue since not many times that user wants to cancel the print but then bails out.

That being said, this feature uses the "Advanced help messages" toggle which, although advised to be enabled for new users, can be disabled from menu.