### PR TITLE
Add quiet zone around QR codes

### DIFF
--- a/Marlin/src/lcd/dwin/dwin_lcd.cpp
+++ b/Marlin/src/lcd/dwin/dwin_lcd.cpp
@@ -577,12 +577,11 @@ void DWIN_Draw_FloatValue(uint8_t bShow, bool zeroFill, uint8_t zeroMode, uint8_
   DWIN_Send(i);
 }
 
-void DWIN_Draw_qrcode(const uint16_t topLeftX, const uint16_t topLeftY, const uint8_t moduleSize, const char *qrcode_data) {
+void DWIN_Draw_qrcode(uint16_t topLeftX, uint16_t topLeftY, const uint8_t moduleSize, const char *qrcode_data) {
   // The structure to manage the QR code
   QRCode qrcode;
 
   // QR version 2 allows strings up to 47 uppercase chars, e.g. "https://bit.ly/qwertyuiop_asdfghjkl_zxcvbnm_123"
-  uint8_t QR_VERSION = 2;
   char uppercase_data[48];
 
   size_t i = 0;
@@ -597,7 +596,9 @@ void DWIN_Draw_qrcode(const uint16_t topLeftX, const uint16_t topLeftY, const ui
 
   qrcode_initText(&qrcode, qrcodeBytes, QR_VERSION, ECC_LOW, uppercase_data);
 
-  DWIN_Draw_Rectangle(1, Color_White, topLeftX, topLeftY, topLeftX + qrcode.size * moduleSize, topLeftY + qrcode.size * moduleSize);
+  DWIN_Draw_Rectangle(1, Color_White, topLeftX, topLeftY, topLeftX + (qrcode.size + QUIET_ZONE_SIZE * 2) * moduleSize, topLeftY + (qrcode.size + QUIET_ZONE_SIZE * 2) * moduleSize);
+  topLeftX = topLeftX + moduleSize * QUIET_ZONE_SIZE;
+  topLeftY = topLeftY + moduleSize * QUIET_ZONE_SIZE;
 
   // top left position marker
   DWIN_Draw_Rectangle(1, Color_Bg_Black, topLeftX, topLeftY, topLeftX + moduleSize * 7, topLeftY + moduleSize * 7);

--- a/Marlin/src/lcd/dwin/dwin_lcd.h
+++ b/Marlin/src/lcd/dwin/dwin_lcd.h
@@ -39,6 +39,13 @@
 #define DWIN_SCROLL_UP   2
 #define DWIN_SCROLL_DOWN 3
 
+#define QR_VERSION 2
+#define QUIET_ZONE_SIZE 3 // quiet zone size in modules
+#define QR_SIZE (QUIET_ZONE_SIZE * 2 + 25) // qr code size in modules
+#define QR_MODULE_SIZE_S 2
+#define QR_MODULE_SIZE_M 3
+#define QR_MODULE_SIZE_L 4
+
 // #define DWIN_CREALITY_480_LCD
 #define DWIN_CREALITY_320_LCD
 

--- a/Marlin/src/lcd/dwin/e3v2/bedLevel_map.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/bedLevel_map.cpp
@@ -216,7 +216,7 @@ void render_bed_mesh_3D()
             break;
     }
     delay(3);
-    DWIN_Draw_qrcode(155, 40, 3, "https://bit.ly/navaismo-bed-leveling");
+    DWIN_Draw_qrcode(DWIN_WIDTH - (QR_SIZE * QR_MODULE_SIZE_M) - 6, 40, QR_MODULE_SIZE_M, "https://bit.ly/NAVAISMO-BED-LEVELING");
     SERIAL_ECHOLN("FINISHED BED MESH 3D LINES");
 }
 

--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -2921,11 +2921,11 @@ void Popup_window_PauseOrStop()
         if (HMI_flag.advanced_help_enabled_flag)
         {
           if (ui.get_progress_percent() < 1) {
-            DWIN_Draw_qrcode(10, 60, 3, "https://bit.ly/NAVAISMO-BED-ADHESION");
-            DWIN_Draw_MultilineString(false, false, font8x16, Color_White, Color_Bg_Window, 92, 60, 17, 17, "Having issues with bed adhesion? See our community Wiki for help");
+            DWIN_Draw_qrcode(DWIN_WIDTH / 2 - ((QR_SIZE * QR_MODULE_SIZE_M) / 2), 40, QR_MODULE_SIZE_M, "https://bit.ly/NAVAISMO-BED-ADHESION");
+            DWIN_Draw_MultilineString(false, false, font8x16, Color_White, Color_Bg_Window, 12, 140, 25, 17, "Having issues with bed adhesion? See our community Wiki for help");
           } else {
-            DWIN_Draw_qrcode(10, 60, 3, "https://bit.ly/NAVAISMO-PRINT-FAILS");
-            DWIN_Draw_MultilineString(false, false, font8x16, Color_White, Color_Bg_Window, 92, 60, 17, 17, "Did your print fail? See our community Wiki for common issues");
+            DWIN_Draw_qrcode(DWIN_WIDTH / 2 - ((QR_SIZE * QR_MODULE_SIZE_M) / 2), 40, QR_MODULE_SIZE_M, "https://bit.ly/NAVAISMO-PRINT-FAILS");
+            DWIN_Draw_MultilineString(false, false, font8x16, Color_White, Color_Bg_Window, 12, 140, 25, 17, "Did your print fail? See our community Wiki for common issues");
           }
         }
         else


### PR DESCRIPTION
Add white margins to QR codes to help some apps detect and scan it.

Fixes #132 